### PR TITLE
Upgraded Terraform null provider to v3.2.0

### DIFF
--- a/terraform/fargate/main.tf
+++ b/terraform/fargate/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.app_name
   environment = var.prefix
-  
+
   tags = {
     Deployment = var.prefix
   }
@@ -15,7 +15,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.2.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   name = var.app_name
   environment = var.prefix
-  
+
   tags = {
     Deployment = var.prefix
   }
@@ -15,7 +15,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.2.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
This is to support deployments of forge-py (via cumulus-tf) on ARM-based Macs